### PR TITLE
TL-51: Introduce status `ready` for api requests; fix linting error

### DIFF
--- a/src/reducers/createTripReducer.ts
+++ b/src/reducers/createTripReducer.ts
@@ -14,7 +14,7 @@ interface createTripAction {
 }
 const initialState = {
   newTrip: {},
-  getCreateTripStatus: requestStatus.loading,
+  getCreateTripStatus: requestStatus.ready,
 };
 
 const createTripReducer = (state = initialState, action: createTripAction): CreateTripState => {

--- a/src/reducers/listByIdReducer.ts
+++ b/src/reducers/listByIdReducer.ts
@@ -14,7 +14,7 @@ interface ListAction {
 
 const initialState = {
   byId: {},
-  getListStatus: requestStatus.loading,
+  getListStatus: requestStatus.ready,
 };
 
 const listByIdReducer = (state = initialState, action: ListAction): ListState => {

--- a/src/reducers/tripsReducer.ts
+++ b/src/reducers/tripsReducer.ts
@@ -16,7 +16,7 @@ interface TripsAction {
 const initialState = {
   ids: [],
   byId: {},
-  getTripsStatus: requestStatus.loading,
+  getTripsStatus: requestStatus.ready,
 };
 
 const tripsReducer = (state = initialState, action: TripsAction): TripsState => {

--- a/src/routes/Trips/Items.tsx
+++ b/src/routes/Trips/Items.tsx
@@ -18,10 +18,10 @@ const Items = ({ listsById, status, fetchList, tripsById }: AppState) => {
   const { id }: any = useParams();
   const currentTrip = tripsById[id];
   useEffect(() => {
-    if (!listsById[currentTrip.listId]) {
+    if (!listsById[currentTrip.listId] && status !== 'loading') {
       fetchList(currentTrip.listId);
     }
-  }, []);
+  });
 
   if (status === 'loading' || !listsById[currentTrip.listId]) {
     return <p className="mt-32  font-sans text-lg font-bold text-center  ">loading...</p>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export enum requestStatus {
+  ready = 'ready',
   loading = 'loading',
   success = 'success',
   error = 'error',


### PR DESCRIPTION
[Jira story](https://triplist.atlassian.net/browse/TL-51)

### What does this PR do?

This PR unblocks the deployment of the last PR by removing the dependency array on the effect ran after `Items` renders. This effect had the trip `id` as a dependency to re-run the effect if it changed. 

The linter was complaining that other variables/props referenced inside the effect were missing on the array.

The solution is to remove the array altogether and put the right checks in place so that the request is only fired once, at the beginning. 

To achieve the above, we had to introduce a new status for the `requestStatus` enum: `ready`

This helps us avoid `loading` as an initial state, so we can rely on it to prevent requests from being fired while another one is on the way.