### PR TITLE
TL-55: request for trips in the background if store has trips 

### DIFF
--- a/src/actions/fetchTrips.ts
+++ b/src/actions/fetchTrips.ts
@@ -3,7 +3,7 @@ export const FETCH_TRIPS_START = 'FETCH_TRIPS_START';
 export const FETCH_TRIPS_SUCCESS = 'FETCH_TRIPS_SUCCESS';
 export const FETCH_TRIPS_ERROR = 'FETCH_TRIPS_ERROR';
 
-const fetchTrips = (doInBackground:boolean) => async (dispatch: any, getState: any) => {
+const fetchTrips = (doInBackground: boolean) => async (dispatch: any, getState: any) => {
   const { userId } = getState().user;
 
   if (!doInBackground) {
@@ -15,7 +15,7 @@ const fetchTrips = (doInBackground:boolean) => async (dispatch: any, getState: a
 
     if (doInBackground) {
       const currentTripsLength = getState.trips.ids.length;
-      
+
       if (trips.length > currentTripsLength) {
         dispatch({ payload: trips, type: FETCH_TRIPS_SUCCESS });
       }

--- a/src/actions/fetchTrips.ts
+++ b/src/actions/fetchTrips.ts
@@ -3,12 +3,24 @@ export const FETCH_TRIPS_START = 'FETCH_TRIPS_START';
 export const FETCH_TRIPS_SUCCESS = 'FETCH_TRIPS_SUCCESS';
 export const FETCH_TRIPS_ERROR = 'FETCH_TRIPS_ERROR';
 
-const fetchTrips = () => async (dispatch: any, getState: any) => {
+const fetchTrips = (doInBackground:boolean) => async (dispatch: any, getState: any) => {
   const { userId } = getState().user;
-  dispatch({ type: FETCH_TRIPS_START });
+
+  if (!doInBackground) {
+    dispatch({ type: FETCH_TRIPS_START });
+  }
 
   try {
     const trips = await request({ method: 'GET', apiDomain: 'https://api.gottapackup.com', path: '/trip', userId });
+
+    if (doInBackground) {
+      const currentTripsLength = getState.trips.ids.length;
+      
+      if (trips.length > currentTripsLength) {
+        dispatch({ payload: trips, type: FETCH_TRIPS_SUCCESS });
+      }
+      return;
+    }
 
     dispatch({ payload: trips, type: FETCH_TRIPS_SUCCESS });
   } catch (e) {

--- a/src/routes/PastTrips/index.tsx
+++ b/src/routes/PastTrips/index.tsx
@@ -16,8 +16,10 @@ type AppState = ComponentStateProps;
 
 const PastTripsList = ({ tripIds, tripsById, fetchTrips, status }: AppState) => {
   useEffect(() => {
-    fetchTrips();
+    const doInBackground = tripIds.length > 0;
+    fetchTrips(doInBackground);
   }, [fetchTrips]);
+
   if (status === 'loading') {
     return <p className="mt-32  font-sans text-lg font-bold text-center  ">loading...</p>;
   }


### PR DESCRIPTION
[Jira story](https://triplist.atlassian.net/browse/TL-55)

### What does this PR do?

The Past Trips page was fetching trips and showing the 'loading' view on every visit, even when the response contains no new trips.

We work around this by introducing an optional `doInBackground` boolean parameter on the `fetchTrips` action creator.

The argument is passed as true if the redux store already contains trips. This will prevent the action creator from dispatching the loading status, while fetching trips in the background and only updating the store if the response contains more trips.